### PR TITLE
protoc-plugin URL changed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>protoc-plugin</id>
-            <url>http://sergei-ivanov.github.com/maven-protoc-plugin/repo/releases/</url>
+            <url>https://github.com/xolstice/protobuf-maven-plugin</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -51,9 +51,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.google.protobuf.tools</groupId>
-                <artifactId>maven-protoc-plugin</artifactId>
-                <version>0.4.0</version>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.5.0</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>


### PR DESCRIPTION
The URL of the protoc-plugin has changed and Maven does not work!
